### PR TITLE
Add support for defining dependecy factories

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -26,8 +26,8 @@ $container->set('auth', function() {
 });
 ?>
 ```
-	
-All instantiation functions are passed the container as the first argument, making 
+
+All instantiation functions are passed the container as the first argument, making
 dependency injection possible:
 
 ```php
@@ -46,7 +46,16 @@ $container->setAuth(function() { // ... }); // Or:
 $container->set_auth(function() { // ... });
 ?>
 ```
-	
+
+By default, dependency instances are cached.  You can force a dependency to always return a new instance by defining it with the factory method.
+
+```php
+<?php
+$container->set('db', $container->factory(function ($container) {
+        return new Db($container);
+}));
+```
+
 ## Getting Objects
 
 Getting objects are as simple as:

--- a/tests/ContainerTests.php
+++ b/tests/ContainerTests.php
@@ -1,8 +1,9 @@
 <?php
 
-require_once '../lib/Zit/Container.php';
+require_once __DIR__.'/../lib/Zit/Container.php';
 require_once 'TestObj.php';
-require_once 'PHPUnit/Framework/TestCase.php';
+// No need to require if we're using phpunit.phar
+// require_once 'PHPUnit/Framework/TestCase.php';
 
 use Zit\Container;
 
@@ -184,5 +185,75 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj);
 		$this->assertAttributeEquals('object one', 'name', $obj);
 	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testCallInvalidMethod() {
+		$c = $this->container;
+		$c->badmethodMe('test');
+	}
+
+	public function testSetWithFactory() {
+		$c = $this->container;
+		$c->set('factory', $c->factory(function () {
+			return new \Zit\TestObj('factory');
+		}));
+
+		$obj1 = $c->get('factory');
+		$this->assertInstanceOf('\\Zit\\TestObj', $obj1);
+
+		$obj2 = $c->getFactory();
+		$this->assertInstanceOf('\\Zit\\TestObj', $obj2);
+		// Make sure the factory returned two separate instances
+		$this->assertNotSame($obj1, $obj2);
+
+		$obj3 = $c->newFactory();
+		$this->assertInstanceOf('\\Zit\\TestObj', $obj3);
+
+		$obj4 = $c->fresh('factory');
+		$this->assertInstanceOf('\\Zit\\TestObj', $obj4);
+		// Make sure the factory returned two separate instances
+		$this->assertNotSame($obj2, $obj3);
+		$this->assertNotSame($obj3, $obj4);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Callback for "invalid" does not exist.
+	 */
+	public function testFreshInvalidCallbackName() {
+		$c = $this->container;
+		$c->fresh('invalid');
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Callback for "invalid" does not exist.
+	 */
+	public function testGetInvalidCallbackName() {
+		$c = $this->container;
+		$c->get('invalid');
+	}
+
+	public function testDelete() {
+		$c = $this->container;
+		$c->set('delete', function() { return new Zit\TestObj('delete'); });
+		$obj1 = $c->get('delete');
+		$obj2 = $c->get('delete');
+		// Verify that we're getting a cached object
+		$this->assertSame($obj1, $obj2);
+		$this->assertTrue($c->delete('delete'));
+		$obj3 = $c->get('delete');
+		// We should get back a new instance
+		$this->assertNotSame($obj1, $obj3);
+	}
+
+	public function testDeleteNoCache() {
+		$c = $this->container;
+		$c->set('delete', function() { return new Zit\TestObj('delete'); });
+		$this->assertFalse($c->delete('delete'));
+	}
+
 }
 


### PR DESCRIPTION
This allows the Container to know when to always create new instances
rather than the consuming code having to know when to call 'fresh()'
