### PR TITLE
Completing Test Coverage

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -30,24 +30,24 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 	{
 		$this->container = null;
 	}
-	
+
 	public function testSetAndHas()
 	{
 		$c = $this->container;
-		
+
 		// Explicit Call
 		$c->set('test', function() {});
 		$this->assertTrue($c->has('test'));
-		
+
 		// Magic Call
 		$c->setTest2(function() {});
 		$this->assertTrue($c->hasTest2());
 	}
-	
+
 	public function testSetParam()
 	{
 		$c = $this->container;
-		
+
 		$c->set('test', 'testing');
 		$this->assertEquals('testing', $c->get('test'));
 
@@ -58,11 +58,11 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$c->setString('test3');
 		$this->assertEquals('test3', $c->get('string'));
 	}
-	
+
 	public function testGet()
 	{
 		$c = $this->container;
-		
+
 		// Explicit Call
 		$c->set('test', function($c, $name) {
 			return new \Zit\TestObj($name);
@@ -70,7 +70,7 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$obj = $c->get('test', 'testing');
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj);
 		$this->assertAttributeEquals('testing', 'name', $obj);
-		
+
 		// Magic Call
 		$c->setAnotherTest(function($c, $name) {
 			return new \Zit\TestObj($name);
@@ -78,67 +78,70 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$obj2 = $c->getAnotherTest('still testing');
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj2);
 		$this->assertAttributeEquals('still testing', 'name', $obj2);
-		
+
 		// Sanity Check
 		$this->assertNotSame($obj, $obj2);
 	}
-	
+
 	public function testFresh()
 	{
 		$c = $this->container;
-		
+
 		$c->setObj(function($c, $name) {
 			return new \Zit\TestObj($name);
 		});
-		
+
 		$o1 = $c->fresh('obj', 'one');
 		$o2 = $c->freshObj('Two');
 		$o3 = $c->fresh_obj('Three');
 		$o4 = $c->newObj('Four');
 		$o5 = $c->new_obj('Five');
-		
+
 		$this->assertNotSame($o1, $o2);
 		$this->assertNotSame($o1, $o3);
 		$this->assertNotSame($o1, $o4);
 		$this->assertNotSame($o1, $o5);
-		
+
 		$this->assertNotSame($o2, $o3);
 		$this->assertNotSame($o2, $o4);
 		$this->assertNotSame($o2, $o5);
-		
+
 		$this->assertNotSame($o3, $o4);
 		$this->assertNotSame($o3, $o5);
-		
+
 		$this->assertNotSame($o4, $o5);
 	}
 
 	public function testFactory()
 	{
 		$c = $this->container;
-		
+
 		$c->setObjFactory(function($c, $name) {
 			return new \Zit\TestObj($name);
 		});
-		
+
 		$o1 = $c->newObj('pizza');
 		$o2 = $c->newObj('pizza');
-		
+
 		$this->assertNotSame($o1, $o2);
-		
+
 		$c->setFactory('obj2', function($c, $name) {
 			return new \Zit\TestObj($name);
 		});
 
 		$o3 = $c->newObj2('pizza');
 		$o4 = $c->newObj2('pizza');
-		
+
 		$this->assertNotSame($o3, $o4);
 	}
-	
+
 	public function testDelete()
 	{
 		$c = $this->container;
 		$c->setObj(function() { return new \stdClass(); });
+
+		$this->assertInstanceOf(stdClass::class,$c->getObj());
+
 		$c->deleteObj();
 
 		try {
@@ -168,72 +171,80 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 
 		$this->assertSame($a, $b);
 	}
-	
+
 	public function testDependency()
 	{
 		$c = $this->container;
-		
+
 		$c->setParent(function() {
 			return new \stdClass();
 		});
-		
+
 		$c->setChild(function($c) {
 			$child = new \stdClass();
 			$child->parent = $c->getParent();
 			return $child;
 		});
-		
+
 		$parent = $c->getParent();
 		$child = $c->getChild();
-		
+
 		$this->assertSame($parent, $child->parent);
 	}
-	
+
 	public function testConstructorArguments()
 	{
 		$c = $this->container;
-		
+
 		$c->setTestObj(function($c, $name) {
 			return new \Zit\TestObj($name);
 		});
-		
+
 		$o1 = $c->getTestObj('A');
 		$o2 = $c->getTestObj();
 		$o3 = $c->newTestObj('B');
 		$o4 = $c->getTestObj('A');
-		
+
 		$this->assertAttributeEquals('A', 'name', $o1);
 		$this->assertAttributeEquals('A', 'name', $o2);
 		$this->assertAttributeEquals('B', 'name', $o3);
 		$this->assertSame($o1, $o4);
 	}
-	
+
 	public function testAlternateMethodFormat()
 	{
 		$c = $this->container;
-		
+
 		$c->set_with_underscores(function($c, $name) {
 			return new \Zit\TestObj($name);
 		});
-		
+
 		$obj = $c->get_with_underscores('Alternate');
-		
+
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj);
 		$this->assertAttributeEquals('Alternate', 'name', $obj);
 	}
-	
+
 	public function testMixedMethodFormat()
 	{
 		$c = $this->container;
-		
+
 		$c->setObjectOne(function() {
 			return new \Zit\TestObj('object one');
 		});
-		
+
 		$obj = $c->get_object_one();
-		
+
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj);
 		$this->assertAttributeEquals('object one', 'name', $obj);
 	}
-}
 
+	public function testInvalidArgumentMethodDoesNotExist()
+	{
+		$c = $this->container;
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$c->somethingThatDoesNotExist();
+	}
+}


### PR DESCRIPTION
This covers the two holes to establish 100% test coverage.

- Creating an object to delete in order to fully cover the delete methods with testDelete().
- Adding a test to confirm the invalid argument exception is thrown.

Before
![before](https://cloud.githubusercontent.com/assets/6137941/21289067/69d36ff6-c450-11e6-97db-988ab897525b.png)

After
![after](https://cloud.githubusercontent.com/assets/6137941/21289069/71d9ff8a-c450-11e6-9874-4ca377661cf7.png)

Happy Holidays.
