### PR TITLE
Complete test coverage

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -239,11 +239,12 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$this->assertAttributeEquals('object one', 'name', $obj);
 	}
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
 	public function testInvalidArgumentMethodDoesNotExist()
 	{
 		$c = $this->container;
-
-		$this->expectException(InvalidArgumentException::class);
 
 		$c->somethingThatDoesNotExist();
 	}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -139,9 +139,10 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 	{
 		$c = $this->container;
 		$c->setObj(function() { return new \stdClass(); });
-		$c->deleteObj();
 
 		$this->assertInstanceOf(stdClass::class,$c->getObj());
+
+		$c->deleteObj();
 
 		try {
 			$c->getObj();
@@ -162,7 +163,7 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 
 		$this->assertNotSame($a, $b);
 
-		$c->deleteObj();
+		$c->deleteObjFactory();
 		$c->setObj(function() { return new \stdClass(); });
 
 		$a = $c->getObj();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -141,6 +141,8 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$c->setObj(function() { return new \stdClass(); });
 		$c->deleteObj();
 
+		$this->assertInstanceOf(stdClass::class,$c->getObj());
+
 		try {
 			$c->getObj();
 		} catch (\InvalidArgumentException $e) {
@@ -234,6 +236,15 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		
 		$this->assertInstanceOf('\\Zit\\TestObj', $obj);
 		$this->assertAttributeEquals('object one', 'name', $obj);
+	}
+
+	public function testInvalidArgumentMethodDoesNotExist()
+	{
+		$c = $this->container;
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$c->somethingThatDoesNotExist();
 	}
 }
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -140,7 +140,7 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$c = $this->container;
 		$c->setObj(function() { return new \stdClass(); });
 
-		$this->assertInstanceOf(stdClass::class,$c->getObj());
+		$this->assertInstanceOf('\\stdClass',$c->getObj());
 
 		$c->deleteObj();
 
@@ -249,4 +249,3 @@ class ContainerTests extends PHPUnit_Framework_TestCase
 		$c->somethingThatDoesNotExist();
 	}
 }
-


### PR DESCRIPTION
This covers the two holes to establish 100% test coverage.

- Creating an object to delete in order to fully cover the delete methods with `testDelete()`.
- Adding a test to confirm the invalid argument exception is thrown.
- Change `deleteObj()` to `deleteObjFactory()` to exercise the underlying code in the `__call()` magic method.

Before
![before](https://cloud.githubusercontent.com/assets/6137941/21289067/69d36ff6-c450-11e6-97db-988ab897525b.png)

After
![after](https://cloud.githubusercontent.com/assets/6137941/21289069/71d9ff8a-c450-11e6-9874-4ca377661cf7.png)

Happy Holidays.
